### PR TITLE
HTBHF-971 Remove PMD warning for not using ConcurrentHashMaps.

### DIFF
--- a/pmd/rulesets.xml
+++ b/pmd/rulesets.xml
@@ -46,6 +46,7 @@
 
     <rule ref="category/java/multithreading.xml">
         <exclude name="DoNotUseThreads" />
+        <exclude name="UseConcurrentHashMap" />
     </rule>
 
     <rule ref="category/java/performance.xml">

--- a/pmd/test-rulesets.xml
+++ b/pmd/test-rulesets.xml
@@ -55,6 +55,7 @@
 
     <rule ref="category/java/multithreading.xml">
         <exclude name="DoNotUseThreads" />
+        <exclude name="UseConcurrentHashMap" />
     </rule>
 
     <rule ref="category/java/performance.xml">


### PR DESCRIPTION
This warning will then fail a build if you use a TreeMap or LinkedHashMap.